### PR TITLE
Fix reshape dimensions from (h, h) to (h, w) for correct image reshaping

### DIFF
--- a/models.py
+++ b/models.py
@@ -227,7 +227,7 @@ class DiT(nn.Module):
 
         x = x.reshape(shape=(x.shape[0], h, w, p, p, c))
         x = torch.einsum('nhwpqc->nchpwq', x)
-        imgs = x.reshape(shape=(x.shape[0], c, h * p, h * p))
+        imgs = x.reshape(shape=(x.shape[0], c, h * p, w * p))
         return imgs
 
     def forward(self, x, t, y):


### PR DESCRIPTION
Although the current code is operational, it assumes square-shaped inputs; this modification provides the correct logical code by accounting for rectangular dimensions.