### PR TITLE
Fix the bug in multi-machine training.

### DIFF
--- a/train.py
+++ b/train.py
@@ -146,7 +146,7 @@ def main(args):
     # Note that parameter initialization is done within the DiT constructor
     ema = deepcopy(model).to(device)  # Create an EMA of the model for use after training
     requires_grad(ema, False)
-    model = DDP(model.to(device), device_ids=[rank])
+    model = DDP(model.to(device))
     diffusion = create_diffusion(timestep_respacing="")  # default: 1000 steps, linear noise schedule
     vae = AutoencoderKL.from_pretrained(f"stabilityai/sd-vae-ft-{args.vae}").to(device)
     logger.info(f"DiT Parameters: {sum(p.numel() for p in model.parameters()):,}")


### PR DESCRIPTION
When using multiple machines, the rank exceeds 8, which is more than the maximum number of GPUs on the current node. The correct approach should not require passing in the rank, because `torch.cuda.set_device(device)` has already been set earlier.